### PR TITLE
Add backend health check endpoint

### DIFF
--- a/backend/railway.json
+++ b/backend/railway.json
@@ -7,7 +7,7 @@
   "deploy": {
     "startCommand": "npx prisma migrate deploy && node dist/server.js",
     "healthcheckPath": "/health",
-    "healthcheckTimeout": 300,
+    "healthcheckTimeout": 60,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 3
   }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -168,19 +168,38 @@ const buildServer = () => {
   });
   fastify.register(swaggerUI, { routePrefix: '/docs', uiConfig: { docExpansion: 'full', deepLinking: false } });
 
+  // Root endpoint for Railway
+  fastify.get('/', async (request, reply) => {
+    return { 
+      message: 'HabitOS API is running',
+      health: '/health',
+      docs: '/docs',
+      status: 'ok'
+    };
+  });
+
   // health + startup-check
   fastify.get('/health', async (request, reply) => {
     try {
+      // Log health check requests for debugging
+      console.log('🏥 Health check requested from:', request.headers['user-agent'] || 'unknown');
+      console.log('🏥 Host header:', request.headers.host);
+      
       // Simple health check - no external calls
-      return { 
+      const response = { 
         ok: true, 
         status: 'healthy',
         timestamp: new Date().toISOString(),
         uptime: process.uptime(),
         version: '1.0.0',
-        environment: process.env.NODE_ENV || 'development'
+        environment: process.env.NODE_ENV || 'development',
+        port: process.env.PORT || 8080
       };
+      
+      console.log('✅ Health check response:', response);
+      return response;
     } catch (error) {
+      console.error('❌ Health check failed:', error);
       reply.code(500);
       return { ok: false, error: 'Health check failed' };
     }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -6,7 +6,7 @@ import swaggerUI from '@fastify/swagger-ui';
 import dotenv from 'dotenv';
 
 import { prisma } from './utils/db';
-import { redis } from './utils/redis';
+import { redis, getRedis } from './utils/redis';
 import OpenAI from 'openai';
 import Stripe from 'stripe';
 import admin from 'firebase-admin';


### PR DESCRIPTION
Improve server resilience for Railway deployments by making database/Redis checks optional during initial startup and health checks.

Railway deployments require a successful health check to generate a domain. Previously, the server would crash if `DATABASE_URL` or `REDIS_URL` were not immediately available, preventing the health check from ever succeeding. This change allows the server to start and respond to basic health checks, even if these environment variables are not yet set, enabling Railway to proceed with deployment and domain generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-06ca644e-173c-40d5-942a-7e052c0cabfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-06ca644e-173c-40d5-942a-7e052c0cabfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

